### PR TITLE
fix: change user_id column type to String in DiaryApplications model

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -179,7 +179,7 @@ class DiaryTasks(db.Model, Serializer):
 class DiaryApplications(db.Model, Serializer):
     __tablename__ = 'diary_applications'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.discord_id'))
+    user_id = db.Column(db.String, db.ForeignKey('users.discord_id'))
     runescape_name = db.Column(db.String, nullable=False)
     diary_name = db.Column(db.String, nullable=False)
     diary_shorthand = db.Column(db.String, nullable=False)


### PR DESCRIPTION
This pull request includes a change to the `models/models.py` file to update the data type of the `user_id` column in the `DiaryApplications` model.

* [`models/models.py`](diffhunk://#diff-f8c536b2618f73297f8c97fd3bc5fd058be8a795af500792953355ed6be1d989L182-R182): Changed the `user_id` column type from `UUID` to `String` to ensure compatibility with the `users.discord_id` foreign key.